### PR TITLE
Updating /fetch-score endpoint

### DIFF
--- a/sample-server/index.js
+++ b/sample-server/index.js
@@ -138,9 +138,9 @@ app.get('/fetch-score', async (req, res) => {
   }
 
   //Get the token of the session from the headers
-  let token = req.headers["x-incode-hardware-id"];
+  let token = req.headers["x-token"];
   if(!token) {
-    res.status(400).send({success:false, error:'Missing required header X-Incode-Hardware-Id'});
+    res.status(400).send({success:false, error:'Missing required header X-Token'});
     return;
   }
   adminHeader['X-Incode-Hardware-Id'] = token;

--- a/sample-server/index.js
+++ b/sample-server/index.js
@@ -136,7 +136,15 @@ app.get('/fetch-score', async (req, res) => {
     res.status(400).send({success:false, error:'Missing required parameter interviewId'});
     return;
   }
-  
+
+  //Get the token of the session from the headers
+  let token = req.headers["x-incode-hardware-id"];
+  if(!token) {
+    res.status(400).send({success:false, error:'Missing required header X-Incode-Hardware-Id'});
+    return;
+  }
+  adminHeader['X-Incode-Hardware-Id'] = token;
+
   //Let's find out the score
   const scoreUrl = `${process.env.API_URL}/omni/get/score`;
   let onboardingScore = null

--- a/sample-server/sample.env
+++ b/sample-server/sample.env
@@ -1,4 +1,0 @@
-API_URL=https://demo-api.incodesmile.com
-API_KEY=
-FLOW_ID=
-ADMIN_TOKEN=


### PR DESCRIPTION
Since the session token was not being passed from the frontend, the backend was not using it and consequently recieving 401 error. In summary:

- Added the session token value to the /omni/get/score endpoint request header;


![Screenshot 2024-04-03 at 20 20 43](https://github.com/Incode-Technologies-Example-Repos/nodejs-samples/assets/164262171/0a1e02e7-3bc9-4c03-a8af-8910c4181ca4)
